### PR TITLE
Allow editing of events if user can publish posts

### DIFF
--- a/admin/class-super-simple-events-admin.php
+++ b/admin/class-super-simple-events-admin.php
@@ -49,6 +49,12 @@ class Super_Simple_Events_Admin {
 	private function __construct() {
 
 		if( ! is_super_admin() ) {
+			if ( current_user_can('publish_posts') ) {
+				$this->plugin = Super_Simple_Events::get_instance();
+				add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 1 );
+				add_action( 'save_post', array( $this, 'save_post' ) );  
+			}
+			
 			return;
 		} 
 
@@ -101,7 +107,7 @@ class Super_Simple_Events_Admin {
 	 */
 	public static function get_instance() {
 
-		if( ! is_super_admin() ) {
+		if( ! current_user_can('publish_posts') ) {
 			return;
 		}
 


### PR DESCRIPTION
From my commit message:
> The meta boxes for editing event data were only shown to super-admins. However, I find it very logical that anyone who can publish a post is also allowed to edit events.

Background: On my WordPress installation, I am the only admin, but I usually don't create the content. All the content creators' accounts have the role `editor` -- but they couldn't see the extra boxes for editing the event metadata until I introduced this change.